### PR TITLE
Change valid data test to use the new list command

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 Custom Template for checking the availability of an entity.
 The main reason for using this template is not because it's complicated, it's because availability is something you will be using over and over when you are dealing with sensors, so being able to repeat the same action over and over is better if there is 1 place in your project the code exists.
 
+This requires HomeAssistant version 2023.11.0 or greater due to the use of the list test in the code.
+
 # Installation
 
 Install this in HACS or download the `availability_template.jinja` from this repository and place the files into your `config\custom_templates` directory.

--- a/availability_template.jinja
+++ b/availability_template.jinja
@@ -4,6 +4,8 @@
       The number of entities that are NOT unknown, unavailable, empty,
       or none are counted.
       If the 2 counts are the same, true is returned, else false, defaults to false.
+    homeassistant:
+      min_version: 2023.11.0
     REMEMBER!!
       This always returns text, so cast to bool on the other end to be
       certain of the result.
@@ -14,9 +16,7 @@
       {{- avail(['entity_1','entity_2']) | bool -}}
   #}
   {# First tests to make sure this is a list #}
-  {%- if entity_list is iterable and
-    (entity_list is not string and entity_list is not mapping)
-  -%}
+  {%- if entity_list is list -%}
     {{- entity_list | map('states') | reject('in', ['unknown','unavailable','','none'])
     | list | count == entity_list | count -}}
   {%- else -%}


### PR DESCRIPTION
Switch to the new list command to test the incomming list.

Now requires minimum Home Assistant 2023-11-0 version.